### PR TITLE
add manual resource type selection

### DIFF
--- a/islandora_doi_framework.module
+++ b/islandora_doi_framework.module
@@ -51,6 +51,12 @@ function islandora_doi_framework_manage_doi() {
     rsort($dois);
   }
 
+  $resourcetype_values = array(
+    'Audiovisual','Collection','Dataset','Event','Image','InteractiveResource',
+    'Model','PhysicalObject','Service','Software','Sound','Text','Workflow',
+    'Other'
+  );
+
   if (count($dois) && strlen($dois[0])) {
     $form['islandora_doi_framework_doi_exists_message'] = array(
       '#markup' => t("This object already has a DOI: !doi. Do you want to update the object's information associated with the DOI?",
@@ -58,6 +64,13 @@ function islandora_doi_framework_manage_doi() {
       '#prefix' => '<div class="messages warning">',
       '#suffix' => '</div>',
     );
+    if (variable_get('islandora_doi_datacite_manual_resourcetype', TRUE)) {
+      $form['islandora_doi_resourcetype'] = array(
+        '#type' => 'select',
+        '#title' => t("Select a resource type for DataCite's API"),
+        '#options' => $resourcetype_values, 
+      );
+    }
     $form['islandora_doi_framework_update_doi'] = array(
       '#type' => 'submit',
       '#value' => 'Update DOI',
@@ -76,6 +89,13 @@ function islandora_doi_framework_manage_doi() {
         array('!pid' => $pid, '!label' => $object->label)),
       '#suffix' => '</div>',
     );
+    if (variable_get('islandora_doi_datacite_manual_resourcetype', TRUE)) {
+      $form['islandora_doi_resourcetype'] = array(
+        '#type' => 'select',
+        '#title' => t("Select a resource type for DataCite's API"),
+        '#options' => $resourcetype_values, 
+      );
+    }
     $form['islandora_doi_framework_assign_doi'] = array(
       '#type' => 'submit',
       '#value' => 'Assign DOI',
@@ -91,7 +111,8 @@ function islandora_doi_framework_manage_doi() {
 function islandora_doi_framework_assign_doi_submit($form, &$form_state) {
   module_load_include('inc', 'islandora_doi_framework', 'includes/utilities');
   $pid = $form_state['values']['islandora_doi_pid'];
-  if ($doi = islandora_doi_framework_mint_doi($pid)) {
+  $resourcetype = $form_state['values']['islandora_doi_resourcetype'];
+  if ($doi = islandora_doi_framework_mint_doi($pid, $resourcetype)) {
     islandora_doi_framework_persist_doi($doi, $pid);
     $form_state['redirect'] = 'islandora/object/' . $pid;
   }

--- a/modules/islandora_doi_datacite/includes/utilities.inc
+++ b/modules/islandora_doi_datacite/includes/utilities.inc
@@ -23,7 +23,7 @@
  * @return string|bool
  *   The DOI if the request was successful, FALSE if not.
  */
-function islandora_doi_datacite_post_new($pid) {
+function islandora_doi_datacite_post_new($pid, $resourcetype) {
   $symbol = variable_get('islandora_doi_datacite_username', 'CISTI.FOO');
   $password = variable_get('islandora_doi_datacite_password', '');
   $suffix_source = variable_get('islandora_doi_datacite_suffix_source', 'pid');
@@ -42,7 +42,7 @@ function islandora_doi_datacite_post_new($pid) {
   // <identifier identifierType="DOI"> element.
   $api_url = variable_get('islandora_doi_datacite_api_url', 'https://mds.datacite.org/') . 'metadata';
 
-  $metadata_xml = islandora_doi_datacite_generate_metadata($pid, $doi);
+  $metadata_xml = islandora_doi_datacite_generate_metadata($pid, $doi, $resourcetype);
 
   $response = drupal_http_request($api_url, array(
     'headers' => array(
@@ -127,14 +127,14 @@ function islandora_doi_datacite_post_new($pid) {
  * @return bool
  *   TRUE if the DOI was updated, FALSE if not.
  */
-function islandora_doi_datacite_update_doi($pid, $doi, $action) {
+function islandora_doi_datacite_update_doi($pid, $doi, $action, $resourcetype) {
   $symbol = variable_get('islandora_doi_datacite_username', 'CISTI.FOO');
   $password = variable_get('islandora_doi_datacite_password', '');
 
   if ($action == 'both' || $action == 'metadata') {
     $api_url = variable_get('islandora_doi_datacite_api_url', 'https://mds.datacite.org/') . 'metadata';
 
-    $metadata_xml = islandora_doi_datacite_generate_metadata($pid, $doi);
+    $metadata_xml = islandora_doi_datacite_generate_metadata($pid, $doi, $resourcetype);
 
     // DataCite's API uses POST to update the metadata.
     $response = drupal_http_request($api_url, array(
@@ -224,7 +224,7 @@ function islandora_doi_datacite_update_doi($pid, $doi, $action) {
  * @return string
  *   The DataCite metadata XML.
  */
-function islandora_doi_datacite_generate_metadata($pid, $doi = NULL) {
+function islandora_doi_datacite_generate_metadata($pid, $doi = NULL, $resourcetype) {
   $object = islandora_object_load($pid);
   $dc_values = islandora_doi_datacite_get_dc_values($object['DC']->content);
 
@@ -268,7 +268,8 @@ function islandora_doi_datacite_generate_metadata($pid, $doi = NULL) {
   // resourceType must be Audiovisual, Collection, Dataset, Event, Image,
   // InteractiveResource, Model, PhysicalObject, Service, Software, Sound,
   // Text, Workflow, or Other.
-  if (isset($dc_values['type'])) {
+  $resource_type = $resourcetype
+  if (isset($dc_values['type']) && variable_get('islandora_doi_datacite_manual_resourcetype', FALSE)) {
     $resource_type = islandora_doi_datacite_normalize_resourcetype($dc_values['type']);
   }
 

--- a/modules/islandora_doi_datacite/islandora_doi_datacite.module
+++ b/modules/islandora_doi_datacite/islandora_doi_datacite.module
@@ -56,6 +56,12 @@ function islandora_doi_datacite_admin_settings() {
     '#default_value' => variable_get('islandora_doi_datacite_password', ''),
     '#description' => t("Your insitution's DataCite password."),
   );
+
+  $form['islandora_doi_datacite_manual_resourcetype'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Manually select DataCite resourceType at DOI assignment?'),
+    '#default_value' => variable_get('islandora_doi_datacite_manual_resourcetype', FALSE),
+  );
   $default_replacements = "StillImage|Image\nThesis|Text";
   $form['islandora_doi_datacite_resourcetype_replacements'] = array(
     '#type' => 'textarea',
@@ -63,6 +69,11 @@ function islandora_doi_datacite_admin_settings() {
     '#rows' => 10,
     '#default_value' => variable_get('islandora_doi_datacite_resourcetype_replacements', $default_replacements),
     '#description' => t("DataCite's metadata specification requires that the values of 'resourceType' are from the list 'Audiovisual', 'Collection', 'Dataset', 'Event', 'Image', 'InteractiveResource', 'Model', 'PhysicalObject', 'Service', 'Software', 'Sound', 'Text', 'Workflow', and 'Other'. You can define a list of source|replacement pairs here that maps values in your DC datastream's 'type' element to one of these values. Place each source and replacement value pair, separated by a |, on its own line."),
+    '#states' => array(
+      'visible' => array(
+        ':input[name=islandora_doi_datacite_manual_resourcetype]' => array('checked' => FALSE),
+      ),
+    ),
   );
   $form['islandora_doi_datacite_combine_creator'] = array(
     '#type' => 'checkbox',
@@ -97,9 +108,9 @@ function islandora_doi_datacite_theme() {
 /**
  * Implements hook_islandora_doi_framework_mint().
  */
-function islandora_doi_datacite_islandora_doi_framework_mint($pid) {
+function islandora_doi_datacite_islandora_doi_framework_mint($pid, $resourcetype) {
   module_load_include('inc', 'islandora_doi_datacite', 'includes/utilities');
-  if ($doi = islandora_doi_datacite_post_new($pid)) {
+  if ($doi = islandora_doi_datacite_post_new($pid, $resourcetype)) {
     return $doi;
   }
   else {
@@ -110,9 +121,9 @@ function islandora_doi_datacite_islandora_doi_framework_mint($pid) {
 /**
  * Implements hook_islandora_doi_framework_update().
  */
-function islandora_doi_datacite_islandora_doi_framework_update($pid, $doi, $action = 'both') {
+function islandora_doi_datacite_islandora_doi_framework_update($pid, $doi, $action = 'both', $resourcetype) {
   module_load_include('inc', 'islandora_doi_datacite', 'includes/utilities');
-  if (islandora_doi_datacite_update_doi($pid, $doi, $action)) {
+  if (islandora_doi_datacite_update_doi($pid, $doi, $action, $resourcetype)) {
     return TRUE;
   }
   else {

--- a/modules/islandora_doi_framework_sample_mint/islandora_doi_framework_sample_mint.module
+++ b/modules/islandora_doi_framework_sample_mint/islandora_doi_framework_sample_mint.module
@@ -20,7 +20,7 @@
 /**
  * Implements hook_islandora_doi_framework_mint().
  */
-function islandora_doi_framework_sample_mint_islandora_doi_framework_mint($pid) {
+function islandora_doi_framework_sample_mint_islandora_doi_framework_mint($pid, $resourcetype) {
   $doi = '10.99999/' . $pid;
   drupal_set_message(t("Sample/test DOI !doi assigned to object !pid.", array('!pid' => $pid, '!doi' => $doi)));
   return $doi;


### PR DESCRIPTION
**Github issue**: https://github.com/mjordan/islandora_doi_framework/issues/4

# What does this Pull Request do?

Add a configuration option to manually select DataCite resource type from a drop-down instead of defining an automatic mapping

# How should this be tested?

Toggle the new configuration option on and off, then check the DOI assignment dialog on an object's properties